### PR TITLE
fix #878: Rename ArgumenstMismatch to ArgumentMismatch

### DIFF
--- a/src/org/rascalmpl/interpreter/TraversalEvaluator.java
+++ b/src/org/rascalmpl/interpreter/TraversalEvaluator.java
@@ -36,7 +36,7 @@ import org.rascalmpl.interpreter.matching.LiteralPattern;
 import org.rascalmpl.interpreter.matching.RegExpPatternValue;
 import org.rascalmpl.interpreter.matching.TypedVariablePattern;
 import org.rascalmpl.interpreter.result.Result;
-import org.rascalmpl.interpreter.staticErrors.ArgumentsMismatch;
+import org.rascalmpl.interpreter.staticErrors.ArgumentMismatch;
 import org.rascalmpl.interpreter.staticErrors.SyntaxError;
 import org.rascalmpl.interpreter.staticErrors.UndeclaredFunction;
 import org.rascalmpl.interpreter.staticErrors.UndeclaredModule;
@@ -351,7 +351,7 @@ public class TraversalEvaluator {
 		    QualifiedName n = Names.toQualifiedName(cons.getType().getName(), cons.getName(), null);
 		    rcons = (IConstructor) eval.call(n, kwParams != null ? kwParams : Collections.<String,IValue>emptyMap(), args);
 		  }
-		  catch (UndeclaredFunction | UndeclaredModule | ArgumentsMismatch e) {
+		  catch (UndeclaredFunction | UndeclaredModule | ArgumentMismatch e) {
 		    // This may happen when visiting data constructors dynamically which are not 
 		    // defined in the current scope. For example, when data was serialized and the format
 		    // has changed in the meantime, or when a generic function from a library calls visit.

--- a/src/org/rascalmpl/interpreter/result/ComposedFunctionResult.java
+++ b/src/org/rascalmpl/interpreter/result/ComposedFunctionResult.java
@@ -26,7 +26,7 @@ import org.rascalmpl.interpreter.TypeReifier;
 import org.rascalmpl.interpreter.control_exceptions.Failure;
 import org.rascalmpl.interpreter.control_exceptions.MatchFailed;
 import org.rascalmpl.interpreter.env.Environment;
-import org.rascalmpl.interpreter.staticErrors.ArgumentsMismatch;
+import org.rascalmpl.interpreter.staticErrors.ArgumentMismatch;
 import org.rascalmpl.value.IAnnotatable;
 import org.rascalmpl.value.IConstructor;
 import org.rascalmpl.value.IExternalValue;
@@ -236,7 +236,7 @@ public class ComposedFunctionResult extends Result<IValue> implements IExternalV
 			} 
 			catch (MatchFailed e) {
 				List<AbstractFunction> candidates = Arrays.<AbstractFunction>asList((AbstractFunction) getLeft(), (AbstractFunction) getRight());
-        throw new ArgumentsMismatch("+ composition", candidates, argTypes, ctx.getCurrentAST());
+        throw new ArgumentMismatch("+ composition", candidates, argTypes, ctx.getCurrentAST());
 			} 
 			catch(Failure f2) {
 				throw new Failure("Both functions in the '+' composition have failed:\n " 

--- a/src/org/rascalmpl/interpreter/staticErrors/ArgumentMismatch.java
+++ b/src/org/rascalmpl/interpreter/staticErrors/ArgumentMismatch.java
@@ -23,20 +23,20 @@ import org.rascalmpl.value.IValue;
 import org.rascalmpl.value.type.Type;
 import org.rascalmpl.value.type.TypeFactory;
 
-public class ArgumentsMismatch extends StaticError {
+public class ArgumentMismatch extends StaticError {
 	private static final long serialVersionUID = -641438732779898646L;
 
-	public ArgumentsMismatch(String name,
+	public ArgumentMismatch(String name,
 			List<AbstractFunction> candidates, Type[] argTypes,
 			AbstractAST ast) {
 		super(computeMessage(name, candidates, argTypes), ast);
 	}
 	
-	public ArgumentsMismatch(String message, AbstractAST ast) {
+	public ArgumentMismatch(String message, AbstractAST ast) {
 		super(message, ast);
 	}
 
-	public ArgumentsMismatch(Result<IValue> function, Type[] argTypes, AbstractAST caller) {
+	public ArgumentMismatch(Result<IValue> function, Type[] argTypes, AbstractAST caller) {
     super(computeMessage(function, argTypes), caller);
   }
 

--- a/src/org/rascalmpl/interpreter/utils/NormalFormValueFactory.java
+++ b/src/org/rascalmpl/interpreter/utils/NormalFormValueFactory.java
@@ -3,7 +3,7 @@ package org.rascalmpl.interpreter.utils;
 import java.util.Map;
 
 import org.rascalmpl.interpreter.IEvaluatorContext;
-import org.rascalmpl.interpreter.staticErrors.ArgumentsMismatch;
+import org.rascalmpl.interpreter.staticErrors.ArgumentMismatch;
 import org.rascalmpl.interpreter.staticErrors.UndeclaredFunction;
 import org.rascalmpl.value.IConstructor;
 import org.rascalmpl.value.IValue;
@@ -30,7 +30,7 @@ public final class NormalFormValueFactory extends AbstractValueFactoryAdapter {
     try {
       return (IConstructor) ctx.getEvaluator().call(cons.getAbstractDataType().getName(), cons.getName());
     }
-    catch (UndeclaredFunction | ArgumentsMismatch e) {
+    catch (UndeclaredFunction | ArgumentMismatch e) {
       // TODO this makes this very robust, but also may hide issues. Not sure what is best here yet.
       return adapted.constructor(cons);
     }
@@ -41,7 +41,7 @@ public final class NormalFormValueFactory extends AbstractValueFactoryAdapter {
     try {
       return (IConstructor) ctx.getEvaluator().call(cons.getAbstractDataType().getName(), cons.getName(), children);
     }
-    catch (UndeclaredFunction | ArgumentsMismatch e) {
+    catch (UndeclaredFunction | ArgumentMismatch e) {
       // TODO this makes this very robust, but also may hide issues. Not sure what is best here yet.
       return adapted.constructor(cons, children);
     }
@@ -54,7 +54,7 @@ public final class NormalFormValueFactory extends AbstractValueFactoryAdapter {
       IConstructor result = (IConstructor) ctx.getEvaluator().call(cons.getAbstractDataType().getName(), cons.getName(), children);
       return result.asAnnotatable().setAnnotations(annotations);
     }
-    catch (UndeclaredFunction | ArgumentsMismatch e) {
+    catch (UndeclaredFunction | ArgumentMismatch e) {
       // TODO this makes this very robust, but also may hide issues. Not sure what is best here yet.
       return adapted.constructor(cons, annotations, children);
     }

--- a/src/org/rascalmpl/library/experiments/Compiler/RVM/Interpreter/RascalFunctionActionExecutor.java
+++ b/src/org/rascalmpl/library/experiments/Compiler/RVM/Interpreter/RascalFunctionActionExecutor.java
@@ -118,7 +118,7 @@ public class RascalFunctionActionExecutor implements IActionExecutor<ITree> {
 //					
 //				return (IConstructor) result.getValue();
 //			}
-//			catch (ArgumentsMismatch e) {
+//			catch (ArgumentMismatch e) {
 //				return ambCluster;
 //			}
 //		}

--- a/src/org/rascalmpl/parser/uptr/action/RascalFunctionActionExecutor.java
+++ b/src/org/rascalmpl/parser/uptr/action/RascalFunctionActionExecutor.java
@@ -17,7 +17,7 @@ import org.rascalmpl.interpreter.control_exceptions.MatchFailed;
 import org.rascalmpl.interpreter.env.Environment;
 import org.rascalmpl.interpreter.result.ICallableValue;
 import org.rascalmpl.interpreter.result.Result;
-import org.rascalmpl.interpreter.staticErrors.ArgumentsMismatch;
+import org.rascalmpl.interpreter.staticErrors.ArgumentMismatch;
 import org.rascalmpl.interpreter.types.NonTerminalType;
 import org.rascalmpl.interpreter.types.RascalTypeFactory;
 import org.rascalmpl.parser.gtd.result.action.IActionExecutor;
@@ -128,7 +128,7 @@ public class RascalFunctionActionExecutor implements IActionExecutor<ITree> {
 					
 				return (ITree) result.getValue();
 			}
-			catch (ArgumentsMismatch e) {
+			catch (ArgumentMismatch e) {
 				return ambCluster;
 			}
 		}

--- a/src/org/rascalmpl/semantics/dynamic/Expression.java
+++ b/src/org/rascalmpl/semantics/dynamic/Expression.java
@@ -70,7 +70,7 @@ import org.rascalmpl.interpreter.result.ICallableValue;
 import org.rascalmpl.interpreter.result.RascalFunction;
 import org.rascalmpl.interpreter.result.Result;
 import org.rascalmpl.interpreter.result.ResultFactory;
-import org.rascalmpl.interpreter.staticErrors.ArgumentsMismatch;
+import org.rascalmpl.interpreter.staticErrors.ArgumentMismatch;
 import org.rascalmpl.interpreter.staticErrors.NonVoidTypeRequired;
 import org.rascalmpl.interpreter.staticErrors.SyntaxError;
 import org.rascalmpl.interpreter.staticErrors.UndeclaredVariable;
@@ -527,7 +527,7 @@ public abstract class Expression extends org.rascalmpl.ast.Expression {
 					res = function.call(types, actuals, kwActuals);
 				}
 				catch (MatchFailed e) {
-				  throw new ArgumentsMismatch(function, types, this);
+				  throw new ArgumentMismatch(function, types, this);
 				}
 				return res;
 			}


### PR DESCRIPTION
The code and the implementation diverged with and without the plural
form. After consultating @jurgenvinju we decided to use the singular
form of the error.